### PR TITLE
Add property for determining whether columns should be reordered

### DIFF
--- a/src/dom-helper.js
+++ b/src/dom-helper.js
@@ -1,4 +1,8 @@
-const stripHtml = element => element.innerHTML.replace(/<[^>]*>?/gm, '')
+const stripHtml = element => {
+  if (element.innerHTML !== undefined) {
+    return element.innerHTML.replace(/<[^>]*>?/gm, '');
+  }
+}
 
 const parseStrDimensionToInt = elementSize => parseInt(elementSize, 10)
 

--- a/src/index.js
+++ b/src/index.js
@@ -427,7 +427,8 @@ export default Component => {
         mode = defaultProps.mode,
         onDraggedColumnChange,
         reorderIndicatorUpClassName = defaultProps.reorderIndicatorUpClassName,
-        reorderIndicatorDownClassName = defaultProps.reorderIndicatorDownClassName
+        reorderIndicatorDownClassName = defaultProps.reorderIndicatorDownClassName,
+        shouldReorder = defaultProps.shouldReorder
       } = draggableColumns
 
       let reorderIndicatorUp = (
@@ -486,12 +487,14 @@ export default Component => {
 
       const previousOrder = [...this.currentColumnOrder]
 
-      // run all reorder events
-      if (mode && mode === DragMode.SWAP) {
-        this.reorder.forEach(o => (cols[o.a] = cols.splice(o.b, 1, cols[o.a])[0]))
-      } else {
-        // mode: reorder - default
-        this.reorder.forEach(o => cols.splice(o.a, 0, cols.splice(o.b, 1)[0]))
+      if (shouldReorder) {
+        // run all reorder events
+        if (mode && mode === DragMode.SWAP) {
+          this.reorder.forEach(o => (cols[o.a] = cols.splice(o.b, 1, cols[o.a])[0]))
+        } else {
+          // mode: reorder - default
+          this.reorder.forEach(o => cols.splice(o.a, 0, cols.splice(o.b, 1)[0]))
+        }
       }
 
       // track final column order
@@ -545,7 +548,8 @@ export default Component => {
     dragImageClassName: 'rt-dragged-item',
     onDragEnterClassName: 'rt-drag-enter-item',
     reorderIndicatorUpClassName: '',
-    reorderIndicatorDownClassName: ''
+    reorderIndicatorDownClassName: '',
+    shouldReorder: true
   }
 
   wrapper.displayName = 'RTDraggableColumn'
@@ -577,7 +581,9 @@ export default Component => {
       /** additional className for reorder indicator Up */
       reorderIndicatorUpClassName: PropTypes.string,
       /** additional className for reorder indicator Down */
-      reorderIndicatorDownClassName: PropTypes.string
+      reorderIndicatorDownClassName: PropTypes.string,
+      /** determines if a reorder should be issued. Defaults to true */
+      shouldReorder: PropTypes.bool
     })
   }
 


### PR DESCRIPTION
This is useful for edge cases where you need to handle a special reordering yourself. So I would for example use the onDropSuccess function to listen to a reorder, but then prevent the lib from doing the reorder so that I instead can do my thing.